### PR TITLE
Silence warning for `setup-go>=v4`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,7 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
+        cache: false
     - run: go version
       shell: bash
     - name: Install Dependencies for v3


### PR DESCRIPTION
Starting with v4, which was introduced in https://github.com/singularityhub/install-singularity/pull/3, caching is enabled by default and leads to warning messages like (https://github.com/singularityhub/install-singularity/actions/runs/7548813340):

```
Restore cache failed: Dependencies file is not found in /home/runner/work/install-singularity/install-singularity. Supported file pattern: go.sum
```

See also https://github.com/actions/setup-go/issues/427.